### PR TITLE
add color to every row of error

### DIFF
--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -140,6 +140,27 @@
           color: #777777;
           text-decoration: none;
       }
+
+      /* Suggestion Row Styling */
+      .hiddenSpellError {
+          border-left-color: rgba(255,0,0, 0.2);
+          border-left-style: solid;
+          cursor: pointer;
+      }
+      .hiddenGrammarError {
+          border-left-color: #fee481;
+          border-left-style: solid;
+          cursor: pointer;
+      }
+      .hiddenSuggestion {
+          border-left-color: rgb(201,205,255);
+          border-left-style: solid;
+          cursor: pointer;
+      }
+      .suggestionRow {
+          padding: 8px;
+          margin-bottom: 8px;
+      }
     </style>
     <script src="popup.js"></script>
     <script src="tools.js"></script>


### PR DESCRIPTION
Add Color to every row of error match and matching the error to match the highlight error on the languagetool website.

Here is how it looks like:
![image](https://cloud.githubusercontent.com/assets/1826884/20017025/7b3b86d4-a2f4-11e6-92c1-0f1966ceee5b.png)
