### PR TITLE
Keep manually selected language

### DIFF
--- a/webextension/callback.js
+++ b/webextension/callback.js
@@ -1,0 +1,35 @@
+class Callback {
+
+    constructor() {}
+
+    static add(name, callback) {
+        // initialize callback;
+        this.getCallbacks();
+        if (this.callbacks[name] === undefined) {
+            this.callbacks[name] = [callback];
+        } else {
+            this.callbacks[name].push(callback);
+        }
+        return true;
+    }
+
+    static run(name) {
+        var callbacks = this.getCallbacks();
+        for (let callback of callbacks[name]) {
+            callback.call();
+        }
+
+        return true;
+    }
+
+    static getCallbacks() {
+        if (!this.callbacks) {
+            this.callbacks = {};
+        }
+        return this.callbacks;
+    }
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = Callback;
+}

--- a/webextension/popup.html
+++ b/webextension/popup.html
@@ -141,6 +141,7 @@
           text-decoration: none;
       }
     </style>
+    <script src="callback.js"></script>
     <script src="popup.js"></script>
     <script src="tools.js"></script>
     <script src="markup.js"></script>

--- a/webextension/popup.js
+++ b/webextension/popup.js
@@ -95,6 +95,7 @@ function getCheckResult(markupList, callback, errorCallback) {
 
 function renderStatus(statusHtml) {
     document.getElementById('status').innerHTML = statusHtml;
+    Callback.run('afterStatusRender');
 }
 
 function getShortCode(languageCode) {
@@ -550,3 +551,42 @@ document.addEventListener('DOMContentLoaded', function() {
 function getStorage() {
     return chrome.storage.sync ? chrome.storage.sync : chrome.storage.local;
 }
+
+function languageSelection() {
+    return document.getElementById('language');
+}
+
+function saveLanguageSelectionToStorage() {
+    let storage = getStorage();
+    if (languageSelection()) {
+        languageSelection().addEventListener('change', (event) => {
+            storage.get('siteLanguage', (result) => {
+                // getting current hostname and path
+                Tools.currentTab((tab) => {
+                    let listOfLanguages = result.siteLanguage || {};
+                    listOfLanguages[Tools.hostAndPath(tab.url)] = event.target.value;
+                    storage.set({
+                        siteLanguage: listOfLanguages
+                    });
+                });
+            });
+        });
+    }
+}
+
+function setLanguageSelectionValue() {
+    let languageElm = languageSelection();
+    if (languageElm) {
+        let storage = getStorage();
+        storage.get('siteLanguage', (result) => {
+            Tools.currentTab((tab) => {
+                let language = result.siteLanguage[Tools.hostAndPath(tab.url)];
+                if (language) {
+                    languageElm.value = language;
+                }
+            })
+        });
+    }
+}
+Callback.add('afterStatusRender', setLanguageSelectionValue);
+Callback.add('afterStatusRender', saveLanguageSelectionToStorage);

--- a/webextension/tools.js
+++ b/webextension/tools.js
@@ -121,6 +121,16 @@ class Tools {
         }
     }
 
+    static hostAndPath(urlString) {
+        let url = new URL(urlString)
+        return url.hostname + url.pathname;
+    }
+
+    static currentTab(callback) {
+        return chrome.tabs.query({currentWindow: true, active: true}, (tab) => {
+            callback.call(this, tab[0]);
+        });
+    }
 }
 
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
Keep manually selected language
fix: #60 
On Chrome:
![fix 60 chrome](https://cloud.githubusercontent.com/assets/1826884/20030094/7b5d8148-a390-11e6-8dff-e0fc801ac468.gif)
On Firefox:
![fix 60 firefox](https://cloud.githubusercontent.com/assets/1826884/20030095/7b625380-a390-11e6-8a32-6b37bfd0eb35.gif)

@danielnaber  It also introduce a new api for tool and a new class called callback. Which we can definitely use for something else. Please let me know though.
