### PR TITLE
Fixed unescaped '{' in format spec

### DIFF
--- a/injectTranslations.py
+++ b/injectTranslations.py
@@ -44,9 +44,9 @@ for k in translatedJson:
     translation = translatedJson[k]['message'].replace("\n", "\\\\n").replace("\"", "\\\"")
     backup = newFile
     quoteRegex = '"[^"\\\]*(?:\\\.[^"\\\]*)*"'    # see http://stackoverflow.com/questions/430759/
-    searchStr = '(" {0} ": {\\s*"message":\\s* {1} )'.format(k, quoteRegex)
+    searchStr = '(" {0} ": {{\\s*"message":\\s* {1} )'.format(k, quoteRegex)
     newFile = re.sub(searchStr,
-                     '"{0}": {\n    "message": "{1}"'.format(k, translation),
+                     '"{0}": {{\n    "message": "{1}"'.format(k, translation),
                      newFile,
                      flags=re.MULTILINE | re.DOTALL)
     if backup == newFile:


### PR DESCRIPTION
Escape '{' that is not supposed to be in format