### PR TITLE
[Fix issue #60] - Keep manually selected language during page session

### DIFF
--- a/webextension/bs/common.js
+++ b/webextension/bs/common.js
@@ -104,7 +104,6 @@ function getCheckResult(markupList, metaData, callback, errorCallback) {
           }
           if (typeof manuallySelectedLanguage !== 'undefined' && manuallySelectedLanguage) {
               params += "&language=" + manuallySelectedLanguage;
-              manuallySelectedLanguage = "";
           } else {
               params += "&language=auto";
               let preferredVariants = [];

--- a/webextension/cs/contentscript.js
+++ b/webextension/cs/contentscript.js
@@ -24,6 +24,7 @@ let toolbarUI;
 let lastUseDate = new Date().getTime();  // TODO: should actually be saved in prefs
 let lastReminderDate = new Date().getTime();  // TODO: should actually be saved in prefs
 let unusedMinutesShowReminder = 0.5;
+let manuallySelectedLanguage = "";
 
 function handleRequest(request, sender, callback) {
     if (request.action === "turnOffAutoCheck") {
@@ -41,6 +42,10 @@ function handleRequest(request, sender, callback) {
     } else if (request.action === 'applyCorrection') {
         applyCorrection(request);
         callback();
+    } else if (request.action === 'saveManuallySelectedLanguage') {
+        manuallySelectedLanguage = request.data.manuallySelectedLanguage;
+    } else if (request.action === 'getManuallySelectedLanguage') {
+        callback(manuallySelectedLanguage);
     } else if (request === 'toggle-in-page-toolbar') {
         if (toolbarUI) {
             toggleToolbar(toolbarUI);


### PR DESCRIPTION
Extension keep manually selected language during page session. Selected value stored in popup context and contet script context. So, if user open popup, set new language and then close popup value will be saved.  Selected value reset when user reload page (refresh, go to another url, etc). 